### PR TITLE
Add shared tracks section and copy controls

### DIFF
--- a/src/components/TopTracks.css
+++ b/src/components/TopTracks.css
@@ -44,11 +44,26 @@ html, body, #root {
   margin-bottom: 18px;
 }
 
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.header-title h2 {
+  margin: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  height: 34px;
+}
+
 .user-filter-bar {
   display: flex;
   justify-content: flex-end;
   align-items: center;
   width: auto;
+  gap: 10px;
 }
 
 .filter-dropdown {
@@ -175,6 +190,13 @@ html, body, #root {
   box-shadow: 0 4px 15px rgba(29, 185, 84, 0.1);
 }
 
+.user-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
 /* Tracks list - Updated for compact layout */
 .tracks-list {
   display: flex;
@@ -231,6 +253,108 @@ html, body, #root {
   align-items: center;
   gap: 6px;
   min-height: 28px;
+}
+
+.copy-tracks-btn {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(24, 24, 24, 0.9);
+  color: white;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.1s ease;
+  white-space: nowrap;
+  width: 40px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  position: relative;
+}
+
+.copy-tracks-btn:hover {
+  border-color: rgba(29, 185, 84, 0.7);
+  background: rgba(29, 185, 84, 0.12);
+}
+
+.copy-tracks-btn:active {
+  transform: scale(0.98);
+}
+
+.copy-selected-btn {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(24, 24, 24, 0.9);
+  color: white;
+  padding: 0;
+  border-radius: 10px;
+  cursor: pointer;
+  width: 40px;
+  height: 34px;
+  line-height: 1;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.1s ease;
+  justify-content: center;
+}
+
+.copy-selected-btn:hover {
+  border-color: rgba(29, 185, 84, 0.7);
+  background: rgba(29, 185, 84, 0.12);
+}
+
+.copy-selected-btn:active {
+  transform: scale(0.98);
+}
+
+.copy-icon {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+.copy-icon::before,
+.copy-icon::after {
+  content: "";
+  position: absolute;
+}
+
+.copy-icon::before {
+  top: 3px;
+  left: 2px;
+  width: 12px;
+  height: 14px;
+  border: 1.6px solid rgba(255, 255, 255, 0.7);
+  border-radius: 3px;
+}
+
+.copy-icon::after {
+  top: 0;
+  left: 4px;
+  width: 12px;
+  height: 14px;
+  border: 1.6px solid rgba(255, 255, 255, 0.95);
+  border-radius: 3px;
+  background: rgba(24, 24, 24, 0.9); /* hide the back lines beneath */
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.copy-tracks-btn:hover .copy-icon::after {
+  border-color: rgba(29, 185, 84, 0.8);
+  background-color: rgba(29, 185, 84, 0.12);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .current-user-badge {
@@ -341,6 +465,10 @@ html, body, #root {
     flex-direction: column;
     align-items: flex-start;
     gap: 10px;
+  }
+
+  .header-title {
+    width: 100%;
   }
 }
 

--- a/src/components/TopTracks.css
+++ b/src/components/TopTracks.css
@@ -33,8 +33,110 @@ html, body, #root {
 }
 
 .tracks-container h2 {
-  margin-bottom: 24px;
-  text-align: center;
+  margin: 0;
+}
+
+.tracks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.user-filter-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: auto;
+}
+
+.filter-dropdown {
+  position: relative;
+  width: 280px;
+}
+
+.filter-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(24, 24, 24, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: white;
+  padding: 10px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.filter-toggle:hover {
+  border-color: rgba(29, 185, 84, 0.5);
+  background-color: rgba(29, 185, 84, 0.08);
+}
+
+.filter-dropdown.open .filter-toggle {
+  border-color: rgba(29, 185, 84, 0.7);
+  background-color: rgba(29, 185, 84, 0.1);
+}
+
+.filter-toggle-label {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.filter-toggle-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.filter-toggle-icon {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-left: 8px;
+}
+
+.filter-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 100%;
+  background: rgba(18, 18, 18, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+  padding: 10px 0;
+  z-index: 5;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.filter-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.filter-option:hover {
+  background: rgba(29, 185, 84, 0.08);
+}
+
+.filter-option input {
+  accent-color: #1DB954;
+}
+
+.filter-option-label {
+  flex: 1;
+}
+
+.filter-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 6px 0;
 }
 
 
@@ -230,6 +332,16 @@ html, body, #root {
   .users-grid {
     grid-template-columns: repeat(2, 1fr); /* 2 users per row on medium screens */
   }
+
+  .filter-dropdown {
+    width: 300px;
+  }
+
+  .tracks-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
 }
 
 @media (max-width: 900px) {
@@ -250,4 +362,12 @@ html, body, #root {
   .tracks-container {
     width: 95%;
   }
-} 
+
+  .tracks-header {
+    align-items: stretch;
+  }
+
+  .filter-dropdown {
+    width: 100%;
+  }
+}

--- a/src/components/TopTracks.css
+++ b/src/components/TopTracks.css
@@ -58,6 +58,120 @@ html, body, #root {
   height: 34px;
 }
 
+.crossover-section {
+  background: linear-gradient(135deg, rgba(29, 185, 84, 0.12), rgba(18, 18, 18, 0.9));
+  border: 1px solid rgba(29, 185, 84, 0.2);
+  border-radius: 14px;
+  padding: 16px;
+  margin-bottom: 18px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.crossover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 10px;
+}
+
+.crossover-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.2px;
+}
+
+.crossover-chip {
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.crossover-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+}
+
+.crossover-card {
+  background: rgba(18, 18, 18, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.crossover-track {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.crossover-rank {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(29, 185, 84, 0.18);
+  color: #1DB954;
+  font-weight: 700;
+  border: 1px solid rgba(29, 185, 84, 0.3);
+}
+
+.crossover-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.crossover-name {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.crossover-artist {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.crossover-users {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.crossover-user {
+  padding: 4px 8px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+}
+
+.crossover-user.current-user {
+  background: rgba(29, 185, 84, 0.2);
+  border-color: rgba(29, 185, 84, 0.45);
+  color: #1DB954;
+}
+
+.crossover-empty {
+  background: rgba(18, 18, 18, 0.8);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  padding: 12px;
+  border-radius: 12px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.95rem;
+}
+
 .user-filter-bar {
   display: flex;
   justify-content: flex-end;

--- a/src/components/TopTracks.tsx
+++ b/src/components/TopTracks.tsx
@@ -1,44 +1,68 @@
-import { useEffect, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { getAllUserTracks } from '../lib/supabase'
-import './TopTracks.css'
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { getAllUserTracks } from "../lib/supabase";
+import "./TopTracks.css";
 
 interface Track {
-  id: string
-  name: string
-  artist: string
-  album: string
-  spotify_id: string
-  rank: number
-  image_url?: string | null
+  id: string;
+  name: string;
+  artist: string;
+  album: string;
+  spotify_id: string;
+  rank: number;
+  image_url?: string | null;
 }
 
 interface UserTracks {
   user: {
-    id: string
-    username: string
-  }
-  tracks: Track[]
+    id: string;
+    username: string;
+  };
+  tracks: Track[];
 }
 
 function TopTracks({ userId }: { userId: string | null }) {
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
 
-  const { data: allUserTracks, error, isLoading: queryLoading } = useQuery<UserTracks[]>({
-    queryKey: ['all-user-tracks'],
+  const {
+    data: allUserTracks,
+    error,
+    isLoading: queryLoading,
+  } = useQuery<UserTracks[]>({
+    queryKey: ["all-user-tracks"],
     queryFn: getAllUserTracks,
     staleTime: 300000, // 5 minutes
     gcTime: 1800000, // 30 minutes
     retry: 2,
-  })
+  });
 
   useEffect(() => {
     if (!queryLoading) {
-      setIsLoading(false)
+      setIsLoading(false);
     }
-  }, [queryLoading])
+  }, [queryLoading]);
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
 
+    if (isDropdownOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isDropdownOpen]);
 
   if (error) {
     return (
@@ -47,67 +71,148 @@ function TopTracks({ userId }: { userId: string | null }) {
           Error loading tracks: {(error as Error).message}
         </div>
       </div>
-    )
+    );
   }
 
   if (isLoading || queryLoading) {
     return (
       <div className="tracks-wrapper">
-        <div className="tracks-container">
-          Loading tracks...
-        </div>
+        <div className="tracks-container">Loading tracks...</div>
       </div>
-    )
+    );
   }
 
-  if (!allUserTracks || !Array.isArray(allUserTracks) || allUserTracks.length === 0) {
+  if (
+    !allUserTracks ||
+    !Array.isArray(allUserTracks) ||
+    allUserTracks.length === 0
+  ) {
     return (
       <div className="tracks-wrapper">
         <div className="tracks-container">
           <div className="no-tracks-message">
-            No tracks found. Try listening to more music or invite your friends to join!
+            No tracks found. Try listening to more music or invite your friends
+            to join!
           </div>
         </div>
       </div>
-    )
+    );
   }
 
   // Sort the current user's tracks to the top if we have a userId
   const sortedUserTracks = [...allUserTracks].sort((a, b) => {
-    if (a.user.id === userId) return -1
-    if (b.user.id === userId) return 1
-    return 0
-  })
+    if (a.user.id === userId) return -1;
+    if (b.user.id === userId) return 1;
+    return 0;
+  });
+
+  const userOptions = sortedUserTracks.map(({ user }) => user);
+
+  const filteredUserTracks = selectedUserIds.length
+    ? sortedUserTracks.filter(({ user }) => selectedUserIds.includes(user.id))
+    : sortedUserTracks;
+
+  const toggleUserSelection = (id: string) => {
+    setSelectedUserIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((userIdItem) => userIdItem !== id)
+        : [...prev, id]
+    );
+  };
+
+  const handleSelectAll = () => {
+    setSelectedUserIds([]);
+  };
+
+  const selectedLabel =
+    selectedUserIds.length === 0
+      ? "All users"
+      : `${selectedUserIds.length} selected`;
 
   return (
     <div className="tracks-wrapper">
       <div className="tracks-container">
-        <h2>Everyone's Top Tracks</h2>
+        <div className="tracks-header">
+          <h2>Everyone's Top Tracks</h2>
+          <div className="user-filter-bar">
+            <div
+              className={`filter-dropdown ${isDropdownOpen ? "open" : ""}`}
+              ref={dropdownRef}
+            >
+              <button
+                type="button"
+                className="filter-toggle"
+                onClick={() => setIsDropdownOpen((open) => !open)}
+              >
+                {/* <span className="filter-toggle-label">Visible users</span> */}
+                <span className="filter-toggle-value">{selectedLabel}</span>
+                <span className="filter-toggle-icon">
+                  {isDropdownOpen ? "▲" : "▼"}
+                </span>
+              </button>
+              {isDropdownOpen && (
+                <div className="filter-menu">
+                  <label className="filter-option">
+                    <input
+                      type="checkbox"
+                      checked={selectedUserIds.length === 0}
+                      onChange={handleSelectAll}
+                    />
+                    <span className="filter-option-label">All users</span>
+                  </label>
+                  <div className="filter-divider" />
+                  {userOptions.map((user) => {
+                    const isSelected = selectedUserIds.includes(user.id);
+                    return (
+                      <label key={user.id} className="filter-option">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleUserSelection(user.id)}
+                        />
+                        <span className="filter-option-label">
+                          {user.id === userId ? "You" : user.username}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
         <div className="users-grid">
-          {sortedUserTracks.map((userTracks: UserTracks) => (
-            <div 
-              key={userTracks.user.id} 
-              className={`user-tracks-section ${userTracks.user.id === userId ? 'current-user' : ''}`}
+          {filteredUserTracks.map((userTracks: UserTracks) => (
+            <div
+              key={userTracks.user.id}
+              className={`user-tracks-section ${
+                userTracks.user.id === userId ? "current-user" : ""
+              }`}
             >
               <h3 className="username">
-                {userTracks.user.id === userId ? 'Your' : `${userTracks.user.username}'s`} Top Tracks
-                {userTracks.user.id === userId && <span className="current-user-badge">You</span>}
+                {userTracks.user.id === userId
+                  ? "Your"
+                  : `${userTracks.user.username}'s`}{" "}
+                Top Tracks
+                {userTracks.user.id === userId && (
+                  <span className="current-user-badge">You</span>
+                )}
               </h3>
               <div className="tracks-list">
                 {userTracks.tracks.map((track: Track) => (
                   <div key={track.id} className="track-list-item">
                     <div className="track-rank">#{track.rank}</div>
-                    
-                    <a 
+
+                    <a
                       href={`https://open.spotify.com/track/${track.spotify_id}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="track-image-link"
                     >
                       {track.image_url ? (
-                        <img 
-                          src={track.image_url} 
-                          alt={`${track.album} cover`} 
+                        <img
+                          src={track.image_url}
+                          alt={`${track.album} cover`}
                           className="album-cover"
                           loading="lazy"
                         />
@@ -117,7 +222,7 @@ function TopTracks({ userId }: { userId: string | null }) {
                         </div>
                       )}
                     </a>
-                    
+
                     <div className="track-details">
                       <div className="track-name">{track.name}</div>
                       <div className="track-artist">{track.artist}</div>
@@ -131,7 +236,7 @@ function TopTracks({ userId }: { userId: string | null }) {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
-export default TopTracks 
+export default TopTracks;


### PR DESCRIPTION
## Summary
- add shared tracks section that surfaces overlapping top tracks for selected users with counts and user chips
- move header copy icon next to filter and preserve copy selected behavior
- fix hook ordering and memoization to avoid render errors while computing shared data

## Testing
- npm run build